### PR TITLE
[UPDATE] Add NVmeFix to the list of installable kexts

### DIFF
--- a/Resources/Kexts/kexts.plist
+++ b/Resources/Kexts/kexts.plist
@@ -4,6 +4,16 @@
 <array>
 	<dict>
 		<key>Name</key>
+		<string>NVmeFix</string>
+		<key>Description</key>
+		<string>NVMeFix is a set of patches for the Apple NVMe storage driver, IONVMeFamily.</string>
+		<key>ProjectUrl</key>
+		<string>https://github.com/acidanthera/NVMeFix</string>
+		<key>Type</key>
+		<string>Lilu</string>
+	</dict>
+	<dict>
+		<key>Name</key>
 		<string>DiskArbitrationFixup</string>
 		<key>Description</key>
 		<string>Lilu plugin for disabling the &quot;The disk you inserted was not readable by this computer&quot; message at boot on 10.9 or later. Useful if you have other disks with filesystems unknown to macOS.</string>


### PR DESCRIPTION
Thought it can be useful also for everybody else is dealing with an NVMe drive draining too much energy on a laptop...

FYI: On my hackintosh laptop the use of this kext extended battery life of roughly 25% _(or a full 1 hour)_