### PR TITLE
Fix retrieving version from project files that contain `MODULE VERSION` inheritance

### DIFF
--- a/Hackintool/AppDelegate.m
+++ b/Hackintool/AppDelegate.m
@@ -3051,7 +3051,7 @@ void authorizationGrantedCallback(AuthorizationRef authorization, OSErr status, 
 		{
 			*projectVersion = [buildSettingsDictionary objectForKey:@"MODULE_VERSION"];
 			
-			if (*projectVersion == nil || [*projectVersion isEqualToString:@"$(CURRENT_PROJECT_VERSION)"] || [*projectVersion isEqualToString:@"$CURRENT_PROJECT_VERSION"])
+			if (*projectVersion == nil || [*projectVersion isEqualToString:@"$(CURRENT_PROJECT_VERSION)"] || [*projectVersion isEqualToString:@"$CURRENT_PROJECT_VERSION"] || [*projectVersion isEqualToString:@"$(MODULE_VERSION)"] || [*projectVersion isEqualToString:@"$MODULE_VERSION"])
 				continue;
 		}
 		


### PR DESCRIPTION
Hi @headkaze!

Pointed out by @mackonsti in https://github.com/OpenIntelWireless/IntelBluetoothFirmware/issues/307, Hackintool fails to retrieve the kext's version when `MODULE VERSION` is inherited.

https://github.com/OpenIntelWireless/IntelBluetoothFirmware/blob/b8646803e7e113a2e9ab26f59ead3d7582794094/IntelBluetoothFirmware.xcodeproj/project.pbxproj#L611

I added some logs and it seems that `MODULE_VERSION = "$(MODULE_VERSION)";` always gets identified first.

```log
$(MODULE_VERSION)
$(MODULE_VERSION)
(null)
2.0.0
```

This PR contains a simple fix, please have a look.

Thanks and have a nice day.