### PR TITLE
Use BrcmFirmwareStore for BrcmPatchRAM BundleID

### DIFF
--- a/Resources/Kexts/kexts.plist
+++ b/Resources/Kexts/kexts.plist
@@ -326,7 +326,7 @@
 		<key>Name</key>
 		<string>BrcmPatchRAM</string>
 		<key>BundleID</key>
-		<string>BrcmPatchRAM3</string>
+		<string>BrcmFirmwareStore</string>
 		<key>Description</key>
 		<string>Broadcom wireless card PatchRAM driver for macOS</string>
 		<key>ProjectUrl</key>


### PR DESCRIPTION
Hi.
Currently Hackintool uses the bundle identifier BrcmPatchRAM3 for BrcmPatchRAM.kext which would only allow detection of installed kext when BrcmPatchRAM3.kext is used, for 10.15 or later. However, this would mean Hackintool would not check if BrcmPatchRAM2.kext for 10.11-10.14 or BrcmPatchRAM.kext for 10.10 or earlier was loaded. Many users like myself still use 10.14 and lower for compatibility reasons, and, on systems that use RAM2 or RAM, the BrcmPatchRAM kext name is not highlighted and installed version information is not displayed in Hackintool->Extensions unlike other kexts, meaning no way of knowing if they need an update unless they manually check the git or use other kext utilities.
Using BundleID of BrcmFirmwareStore as in BrcmFirmwareRepo.kext and BrcmFirmwareData.kext which contain the firmware for BrcmPatchRAMX.kext, Hackintool can now detect the use of BrcmPatchRAM regardless of which BrcmPatchRAMX.kext is being used because either the user must install one of the two firmware kexts.
I actually left a reply in the Hackintool thread in InsanelyMac a long time ago which did not seem to catch your attention.

Regards,
whatnameisit